### PR TITLE
fix(jest-integration): add `require` to `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "jsdelivr": "dist/d3-array.min.js",
   "unpkg": "dist/d3-array.min.js",
   "exports": {
+    "require": "./dist/d3-array.min.js",
     "umd": "./dist/d3-array.min.js",
     "default": "./src/index.js"
   },


### PR DESCRIPTION
This change follows the advice from:
- https://github.com/facebook/jest/issues/12036#issuecomment-1039479569

Tested locally: the change fixes the problem with `jest` trying to use the `default` path.

---

Perhaps it'd be desired to update all `d3-*` packages to include the `require` prop on the `export` object.